### PR TITLE
user-runtime-dir@.service: don't stop on runlevel switch

### DIFF
--- a/units/user-runtime-dir@.service.in
+++ b/units/user-runtime-dir@.service.in
@@ -12,6 +12,7 @@ Description=/run/user/%i mount wrapper
 Documentation=man:user@.service(5)
 After=systemd-user-sessions.service
 StopWhenUnneeded=yes
+IgnoreOnIsolate=yes
 
 [Service]
 ExecStart=@rootlibexecdir@/systemd-user-runtime-dir start %i


### PR DESCRIPTION
Followup to commit 13cf422e04b7 ("user@.service: don't kill user manager at runlevel switch")

I think there's a general rule that units with `StopWhenUnneeded=yes` need
`IgnoreOnIsolate=yes`...  But it doesn't apply to `suspend.target` and friends.
`printer.target` and friends break on isolate even if we apply the rule[1].
That just leaves `graphical-session.target`, which is a user service.
"isolate" is *mostly* a weird attempt to emulate runlevels, so I decided
not to worry about it for user services.

[1] https://github.com/systemd/systemd/issues/6505#issuecomment-320644819